### PR TITLE
feat: allow dcterms_issued to be null in elasticsearch

### DIFF
--- a/types/search/index.d.ts
+++ b/types/search/index.d.ts
@@ -95,4 +95,6 @@ export interface SearchResultItem {
 	plays_count: number;
 	bookmarks_count: number;
 	collection_labels?: string[];
+	created_at: string;
+	updated_at: string;
 }


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-1195